### PR TITLE
Fix ES module imports for production deployment

### DIFF
--- a/backend/src/models/Court.ts
+++ b/backend/src/models/Court.ts
@@ -1,4 +1,4 @@
-import pool from '../../config/database';
+import pool from '../../config/database.js';
 
 export interface Court {
 

--- a/backend/src/routes/courts.ts
+++ b/backend/src/routes/courts.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { CourtModel } from '../models/Court';
+import { CourtModel } from '../models/Court.js';
 
 const router = express.Router();
 

--- a/backend/tests/integration/courts.test.ts
+++ b/backend/tests/integration/courts.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import express from 'express';
-import courtRoutes from '../../src/routes/courts';
-import { setupTestDatabase, teardownTestDatabase, clearTestData, testPool } from '../helpers/database';
+import courtRoutes from '../../src/routes/courts.js';
+import { setupTestDatabase, teardownTestDatabase, clearTestData, testPool } from '../helpers/database.js';
 
 // Create a test app
 const app = express();

--- a/backend/tests/unit/models/Court.test.ts
+++ b/backend/tests/unit/models/Court.test.ts
@@ -1,4 +1,4 @@
-import { CourtModel } from '../../../src/models/Court';
+import { CourtModel } from '../../../src/models/Court.js';
 
 // Mock the database pool - this replaces the real database with fake functions
 jest.mock('../../../config/database', () => ({


### PR DESCRIPTION
- Add .js extensions to all relative imports in backend
- Fixes 'Cannot find module' error in Render deployment
- Required for Node.js ES modules in production environment
- Affects: routes, models, tests, and migration scripts