### PR TITLE
Fix module system conflict: remove type module from backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,6 @@
   "name": "@courtpulse/backend",
   "version": "1.0.0",
   "private": true,
-  "type": "module",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch --clear-screen=false index.ts",
     "start": "NODE_ENV=production node dist/index.js",


### PR DESCRIPTION
- Remove 'type: module' from backend/package.json
- TypeScript compiles to CommonJS but package.json was forcing ES modules
- This was causing 'exports is not defined in ES module scope' error
- Now CommonJS compiled files will run correctly in production