### PR TITLE
fix(auth): capture magic-link email send failures to Sentry

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import crypto from 'crypto';
+import * as Sentry from '@sentry/node';
 import pool from '../../config/database';
 import { authenticateUser, requireAuth, AuthenticatedRequest } from '../middleware/auth';
 import { asyncHandler } from '../middleware/errorHandler';
@@ -68,8 +69,22 @@ router.post(
     const baseUrl = process.env.FRONTEND_URL || process.env.PUBLIC_APP_URL || 'http://localhost:3000';
     const verifyUrl = `${baseUrl}/auth/verify-magic-link?token=${token}`;
     const sent = await sendMagicLinkEmail(email, verifyUrl);
-    if (!sent.ok && process.env.NODE_ENV !== 'production') {
-      console.log('[Auth] Magic link (dev, email not sent):', verifyUrl);
+
+    if (!sent.ok) {
+      // Email send failed — user just saw "check your email" but nothing was sent.
+      // Capture as a Sentry Issue so we get alerted; tagged so we can filter the
+      // "RESEND_API_KEY missing" case (config bug) from real Resend failures.
+      Sentry.captureException(
+        new Error(`Magic link email failed to send: ${sent.error}`),
+        {
+          tags: { feature: 'auth', action: 'send_magic_link' },
+          extra: { email, reason: sent.error, env: process.env.NODE_ENV }
+        }
+      );
+
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[Auth] Magic link (dev, email not sent):', verifyUrl);
+      }
     }
 
     // Same message whether or not user exists (don't leak account existence)


### PR DESCRIPTION
**Discovered in production**: tried signing up on the freshly deployed app, got "check your email", no email arrived. RESEND_API_KEY wasn't set yet — but nothing in Sentry surfaced the failure.

Root cause: \`sendMagicLinkEmail\` returns \`{ ok: false, error }\` on failure, and the route handler ignored it in production (only dev had a console.log fallback). The user-facing response stays the same generic "if an account exists…" message either way (for account-enumeration safety), so the silent failure was completely invisible to ops.

Fix: \`Sentry.captureException\` on \`!sent.ok\` with tags \`feature: 'auth', action: 'send_magic_link'\` and extras carrying email + reason + env. Dev console.log of the verify URL preserved for local-only fallback. No change to the response body.

After this lands, the missing-RESEND_API_KEY case will fire a Sentry Issue immediately on the first sign-in attempt instead of staying hidden.