### PR TITLE
feat(courts): add court creation and deletion flows

### DIFF
--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -32,11 +32,12 @@ export const searchRateLimit = rateLimit({
 // Rate limiter for magic link requests.
 // Keyed by normalized email rather than IP — one shared office IP shouldn't
 // block legitimate users, but one email address being bombarded should.
-// 1 request per email per minute is enough to stop email bombing while staying
-// invisible to a user who fat-fingers the submit button.
+// 3 requests per email per minute — tolerates a user retrying a couple times
+// (e.g. fat-fingered submit, or the first link landed in spam) while still
+// blocking email bombing.
 export const magicLinkRateLimit = rateLimit({
   windowMs: 60 * 1000,
-  max: 1,
+  max: 3,
   standardHeaders: true,
   legacyHeaders: false,
   // Skip the limiter entirely if there's no email in the body. The route handler

--- a/backend/src/models/Court.ts
+++ b/backend/src/models/Court.ts
@@ -94,9 +94,13 @@ export class CourtModel {
 
     static async create(courtData: CourtInput): Promise<Court> {
         const { name, type, lat, lng, surface, is_public, has_lights } = courtData;
+        // Store the user-entered name in both facility_name (used by reads via
+        // COALESCE(facility_name, 'Unknown') as cluster_group_name) and fallback_name
+        // (legacy fallback for the per-court name). Without setting facility_name,
+        // a refetch immediately after create would return cluster_group_name='Unknown'.
         const result = await pool.query(`
-            INSERT INTO courts (fallback_name, sport, centroid, surface_type, is_public, has_lights, region)
-            VALUES ($1, $2, ST_SetSRID(ST_MakePoint($3, $4), 4326), $5, $6, $7, 'sf_bay')
+            INSERT INTO courts (facility_name, fallback_name, sport, centroid, surface_type, is_public, has_lights, region)
+            VALUES ($1::text, $1::varchar, $2, ST_SetSRID(ST_MakePoint($3, $4), 4326), $5, $6, $7, 'sf_bay')
             RETURNING 
                 id, 
                 COALESCE(individual_court_name, fallback_name, 'Unknown Court') as name,

--- a/backend/src/models/Court.ts
+++ b/backend/src/models/Court.ts
@@ -34,6 +34,7 @@ export interface CourtInput {
     is_public: boolean;
     has_lights?: boolean | null;
     cluster_group_name?: string | null;
+    court_name?: string | null;
     school?: boolean;
 }
 
@@ -93,14 +94,16 @@ export class CourtModel {
     }
 
     static async create(courtData: CourtInput): Promise<Court> {
-        const { name, type, lat, lng, surface, is_public, has_lights } = courtData;
+        const { name, type, lat, lng, surface, is_public, has_lights, court_name } = courtData;
         // Store the user-entered name in both facility_name (used by reads via
         // COALESCE(facility_name, 'Unknown') as cluster_group_name) and fallback_name
         // (legacy fallback for the per-court name). Without setting facility_name,
         // a refetch immediately after create would return cluster_group_name='Unknown'.
+        // The optional court_name goes into individual_court_name; reads COALESCE it
+        // over fallback_name so when present it takes precedence as the per-court label.
         const result = await pool.query(`
-            INSERT INTO courts (facility_name, fallback_name, sport, centroid, surface_type, is_public, has_lights, region)
-            VALUES ($1::text, $1::varchar, $2, ST_SetSRID(ST_MakePoint($3, $4), 4326), $5, $6, $7, 'sf_bay')
+            INSERT INTO courts (facility_name, fallback_name, individual_court_name, sport, centroid, surface_type, is_public, has_lights, region)
+            VALUES ($1::text, $1::varchar, $8::varchar, $2, ST_SetSRID(ST_MakePoint($3, $4), 4326), $5, $6, $7, 'sf_bay')
             RETURNING 
                 id, 
                 COALESCE(individual_court_name, fallback_name, 'Unknown Court') as name,
@@ -116,7 +119,7 @@ export class CourtModel {
                 region,
                 created_at, 
                 updated_at
-        `, [name, type, lng, lat, surface, is_public, has_lights ?? null]);
+        `, [name, type, lng, lat, surface, is_public, has_lights ?? null, court_name ?? null]);
         return result.rows[0];
     }
 

--- a/backend/src/models/Court.ts
+++ b/backend/src/models/Court.ts
@@ -53,8 +53,8 @@ export class CourtModel {
                 COALESCE(individual_court_name, fallback_name, 'Unknown Court') as name,
                 COALESCE(facility_name, 'Unknown') as cluster_group_name,
                 sport as type, 
-                ST_X(centroid::geometry) as lat, 
-                ST_Y(centroid::geometry) as lng,
+                ST_Y(centroid::geometry) as lat,
+                ST_X(centroid::geometry) as lng,
                 COALESCE(surface_type::text, 'Unknown') as surface, 
                 is_public,
                 has_lights,
@@ -76,8 +76,8 @@ export class CourtModel {
                 COALESCE(individual_court_name, fallback_name, 'Unknown Court') as name,
                 COALESCE(facility_name, 'Unknown') as cluster_group_name,
                 sport as type, 
-                ST_X(centroid::geometry) as lat, 
-                ST_Y(centroid::geometry) as lng,
+                ST_Y(centroid::geometry) as lat,
+                ST_X(centroid::geometry) as lng,
                 COALESCE(surface_type::text, 'Unknown') as surface, 
                 is_public,
                 has_lights,
@@ -104,13 +104,13 @@ export class CourtModel {
         const result = await pool.query(`
             INSERT INTO courts (facility_name, fallback_name, individual_court_name, sport, centroid, surface_type, is_public, has_lights, region)
             VALUES ($1::text, $1::varchar, $8::varchar, $2, ST_SetSRID(ST_MakePoint($3, $4), 4326), $5, $6, $7, 'sf_bay')
-            RETURNING 
-                id, 
+            RETURNING
+                id,
                 COALESCE(individual_court_name, fallback_name, 'Unknown Court') as name,
                 COALESCE(facility_name, 'Unknown') as cluster_group_name,
-                sport as type, 
-                ST_X(centroid::geometry) as lat, 
-                ST_Y(centroid::geometry) as lng,
+                sport as type,
+                ST_Y(centroid::geometry) as lat,
+                ST_X(centroid::geometry) as lng,
                 COALESCE(surface_type::text, 'Unknown') as surface, 
                 is_public,
                 has_lights,

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -70,6 +70,12 @@ router.post(
     const verifyUrl = `${baseUrl}/auth/verify-magic-link?token=${token}`;
     const sent = await sendMagicLinkEmail(email, verifyUrl);
 
+    // In dev, always log the link so you can sign in without relying on email
+    // delivery (corporate filters block localhost links).
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[Auth] Magic link:', verifyUrl);
+    }
+
     if (!sent.ok) {
       // Email send failed — user just saw "check your email" but nothing was sent.
       // Capture as a Sentry Issue so we get alerted; tagged so we can filter the

--- a/backend/src/routes/courts.ts
+++ b/backend/src/routes/courts.ts
@@ -8,6 +8,7 @@ import { searchRateLimit } from '../middleware/rateLimiter';
 import { asyncHandler } from '../middleware/errorHandler';
 import { authenticateUser, requireAuth, requireAdmin, AuthenticatedRequest } from '../middleware/auth';
 import { setAuditContext } from '../utils/auditContext';
+import { sendDeletionRequestEmail } from '../services/email';
 import {
   InvalidIdException,
   InvalidBboxException,
@@ -214,7 +215,7 @@ router.post(
       type,
       lat: location.lat,
       lng: location.lng,
-      surface: surface || 'Unknown',
+      surface: surface || 'other',
       is_public: is_public ?? true,
       has_lights: has_lights ?? null
     });
@@ -315,6 +316,40 @@ router.put(
       success: true,
       data: court
     });
+  })
+);
+
+/**
+ * POST /api/courts/:id/deletion-request
+ * Request deletion of a court (contributor flow — emails admin for review)
+ */
+router.post(
+  '/:id/deletion-request',
+  authenticateUser,
+  requireAuth,
+  asyncHandler(async (req: AuthenticatedRequest, res: express.Response) => {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) throw new InvalidIdException('court');
+
+    const court = await CourtModel.findById(id);
+    if (!court) throw new CourtNotFoundException(id);
+
+    const { reason } = req.body;
+    const requester = req.user!;
+
+    await sendDeletionRequestEmail({
+      courtId: id,
+      courtName: court.cluster_group_name || court.name || `Court #${id}`,
+      requesterEmail: requester.email,
+      reason: reason || null,
+    });
+
+    Sentry.logger.info('Court deletion requested', {
+      courtId: id,
+      requestedBy: requester.email,
+    });
+
+    return res.json({ success: true, message: 'Deletion request submitted' });
   })
 );
 

--- a/backend/src/routes/courts.ts
+++ b/backend/src/routes/courts.ts
@@ -189,7 +189,7 @@ router.post(
   authenticateUser,
   requireAuth,
   asyncHandler(async (req: AuthenticatedRequest, res: express.Response) => {
-    const { name, type, location, surface, is_public, has_lights } = req.body;
+    const { name, type, location, surface, is_public, has_lights, court_name } = req.body;
 
     // Validation - throw specific exceptions
     const missingFields: string[] = [];
@@ -217,7 +217,8 @@ router.post(
       lng: location.lng,
       surface: surface || 'other',
       is_public: is_public ?? true,
-      has_lights: has_lights ?? null
+      has_lights: has_lights ?? null,
+      court_name: court_name ?? null
     });
 
     await pool.query(`UPDATE users SET edits_count = edits_count + 1 WHERE id = $1`, [req.user!.id]);

--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -30,3 +30,33 @@ export async function sendMagicLinkEmail(to: string, verifyUrl: string): Promise
   }
   return { ok: true };
 }
+
+const ADMIN_EMAIL = 'matthewmctighe1@gmail.com';
+
+export async function sendDeletionRequestEmail(params: {
+  courtId: number;
+  courtName: string;
+  requesterEmail: string;
+  reason: string | null;
+}): Promise<void> {
+  const { courtId, courtName, requesterEmail, reason } = params;
+
+  if (!resend) {
+    throw new Error('Email service not configured — cannot send deletion request');
+  }
+
+  await resend.emails.send({
+    from: fromEmail,
+    to: [ADMIN_EMAIL],
+    subject: `Court deletion request: ${courtName}`,
+    html: `
+      <p><strong>${requesterEmail}</strong> has requested that the following court be deleted:</p>
+      <ul>
+        <li><strong>Court:</strong> ${courtName} (ID: ${courtId})</li>
+        <li><strong>Reason:</strong> ${reason || 'No reason provided'}</li>
+        <li><strong>Requested by:</strong> ${requesterEmail}</li>
+      </ul>
+      <p>Log in to CourtPulse as admin to delete this court.</p>
+    `,
+  });
+}

--- a/frontend/components/CourtsMap.tsx
+++ b/frontend/components/CourtsMap.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import MapTypeToggle from './MapTypeToggle';
 import EditCourtModal from './EditCourtModal';
+import CreateCourtModal from './CreateCourtModal';
 import NoDataModal from './NoDataModal';
 import AuthRequiredModal from './AuthRequiredModal';
 import { useAuth } from '../lib/auth/AuthContext';
@@ -17,6 +18,9 @@ import { AuthExpiredError } from '@/lib/api';
 import {
   searchCourts,
   updateCourt,
+  createCourt,
+  deleteCourt,
+  requestCourtDeletion,
   getCoverageAreas,
   NetworkError,
   APIError,
@@ -69,6 +73,9 @@ export default function CourtsMap({
   const [editingCourt, setEditingCourt] = useState<Court | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+  const [isPlacementMode, setIsPlacementMode] = useState(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [pendingCourtLocation, setPendingCourtLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [viewport, setViewport] = useState(externalViewport);
   const [debouncedViewport, setDebouncedViewport] = useState(externalViewport);
   const [coverageAreas, setCoverageAreas] = useState<CoverageArea[]>([]);
@@ -835,6 +842,95 @@ export default function CourtsMap({
     setMapType(newMapType);
   };
 
+  // Handle "Add Court" FAB click
+  const handleAddCourtClick = () => {
+    if (!user) {
+      setIsAuthModalOpen(true);
+      return;
+    }
+    setIsPlacementMode(true);
+    setSelectedCluster(null);
+  };
+
+  // Handle map click during placement mode
+  const handleMapClick = (evt: { lngLat: { lat: number; lng: number } }) => {
+    if (!isPlacementMode) return;
+    setPendingCourtLocation({ lat: evt.lngLat.lat, lng: evt.lngLat.lng });
+    setIsPlacementMode(false);
+    setIsCreateModalOpen(true);
+  };
+
+  // Handle court creation submission
+  const handleCreateCourt = async (data: {
+    cluster_group_name: string;
+    name: string | null;
+    type: string;
+    lat: number;
+    lng: number;
+    surface: string;
+    is_public: boolean;
+    has_lights: boolean | null;
+  }) => {
+    try {
+      const created = await createCourt({
+        name: data.cluster_group_name,
+        type: data.type,
+        location: { lat: data.lat, lng: data.lng },
+        surface: data.surface,
+        is_public: data.is_public,
+        has_lights: data.has_lights,
+      });
+
+      setCourts(prev => [...prev, { ...created, cluster_group_name: data.cluster_group_name, name: data.name }]);
+      toast.success('Court added', { description: data.cluster_group_name });
+      setIsCreateModalOpen(false);
+      setPendingCourtLocation(null);
+
+      // Fly to the new court so the user sees it appear
+      if (mapRef.current) {
+        mapRef.current.flyTo({
+          center: [data.lng, data.lat],
+          zoom: Math.max(viewport.zoom, 15),
+          duration: 800,
+        });
+      }
+
+      // Invalidate cache for current viewport and refetch so the court persists
+      const { bbox } = calculateBoundingBox(viewport);
+      const cacheKey = createCacheKey(bbox);
+      if (courtCache.current.has(cacheKey)) {
+        courtCache.current.delete(cacheKey);
+        const orderIndex = cacheKeysOrder.current.indexOf(cacheKey);
+        if (orderIndex > -1) cacheKeysOrder.current.splice(orderIndex, 1);
+        delete courtsByBbox.current[cacheKey];
+      }
+      setTimeout(() => fetchCourtsForArea(), 500);
+
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { component: 'CourtsMap', action: 'handleCreateCourt' },
+        extra: { lat: data.lat, lng: data.lng },
+      });
+
+      if (err instanceof AuthExpiredError) {
+        toast.error('Session expired', { description: 'Please sign in again to continue.' });
+        setIsCreateModalOpen(false);
+        setPendingCourtLocation(null);
+        await logout();
+        router.push('/auth/login');
+        return;
+      }
+
+      if (err instanceof NetworkError) {
+        toast.error('Unable to connect', { description: 'The server may be temporarily unavailable.' });
+      } else if (err instanceof APIError) {
+        toast.error('Failed to add court', { description: err.message });
+      } else {
+        toast.error('Failed to add court', { description: 'Please try again.' });
+      }
+    }
+  };
+
   // Handle edit button click
   const handleEditClick = (court: Court) => {
     if (!user) {
@@ -844,6 +940,63 @@ export default function CourtsMap({
     setEditingCourt(court);
     setIsEditModalOpen(true);
     setSelectedCluster(null); // Close popup when opening edit modal
+  };
+
+  // Handle admin delete
+  const handleDeleteCourt = async (court: Court) => {
+    try {
+      await deleteCourt(court.id);
+      setCourts(prev => prev.filter(c => c.id !== court.id));
+      setSelectedCluster(null);
+      toast.success('Court deleted');
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { component: 'CourtsMap', action: 'handleDeleteCourt' },
+        extra: { courtId: court.id },
+      });
+      if (err instanceof AuthExpiredError) {
+        toast.error('Session expired', { description: 'Please sign in again.' });
+        await logout();
+        router.push('/auth/login');
+        return;
+      }
+      if (err instanceof NetworkError) {
+        toast.error('Unable to connect', { description: 'Please try again.' });
+      } else if (err instanceof APIError) {
+        toast.error('Delete failed', { description: err.message });
+      } else {
+        toast.error('Delete failed', { description: 'Please try again.' });
+      }
+    }
+  };
+
+  // Handle contributor deletion request
+  const handleRequestDeletion = async (court: Court) => {
+    try {
+      await requestCourtDeletion(court.id);
+      setSelectedCluster(null);
+      toast.success('Deletion request submitted', {
+        description: 'An admin will review your request.',
+      });
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { component: 'CourtsMap', action: 'handleRequestDeletion' },
+        extra: { courtId: court.id },
+      });
+      if (err instanceof AuthExpiredError) {
+        toast.error('Session expired', { description: 'Please sign in again.' });
+        await logout();
+        router.push('/auth/login');
+        return;
+      }
+      if (err instanceof NetworkError) {
+        toast.error('Unable to connect', { description: 'Please try again.' });
+      } else if (err instanceof APIError) {
+        toast.error('Request failed', { description: err.message });
+      } else {
+        toast.error('Request failed', { description: 'Please try again.' });
+      }
+    }
   };
 
   // Handle save from edit modal
@@ -980,6 +1133,33 @@ export default function CourtsMap({
         </div>
       )}
 
+      {/* Placement Mode Banner */}
+      {isPlacementMode && (
+        <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-20 flex items-center gap-3 bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg">
+          <span className="text-sm font-medium">Click the map to place your court</span>
+          <button
+            onClick={() => setIsPlacementMode(false)}
+            className="text-blue-200 hover:text-white text-sm underline"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Add Court FAB - Bottom Right above map type toggle */}
+      {!isPlacementMode && (
+        <button
+          onClick={handleAddCourtClick}
+          className="absolute bottom-20 right-4 z-10 flex items-center gap-2 px-4 py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-full shadow-lg transition-colors"
+          title={user ? 'Add a new court' : 'Sign in to add a court'}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Add Court
+        </button>
+      )}
+
       {/* Refresh Button Overlay - Centered */}
       <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-10">
         <button
@@ -1027,7 +1207,8 @@ export default function CourtsMap({
         onError={(error) => {
           // Map error occurred
         }}
-        style={{ width: '100%', height: '100%' }}
+        onClick={handleMapClick}
+        style={{ width: '100%', height: '100%', cursor: isPlacementMode ? 'crosshair' : 'grab' }}
         mapStyle={mapStyle}
         attributionControl={false}
         logoPosition="bottom-left"
@@ -1130,31 +1311,51 @@ export default function CourtsMap({
                 <p><span className="font-medium">School:</span> {selectedCluster.properties.school ? 'Yes' : 'No'}</p>
               </div>
               
-              <div className="flex justify-center">
-                <button
-                  onClick={() => {
-                    const courtDetail = {
-                      id: selectedCluster.properties.id || selectedCluster.id,
-                      name: selectedCluster.properties.name || 'Unknown Court',
-                      type: selectedCluster.properties.type || 'unknown',
-                      lat: selectedCluster.geometry.coordinates[1],
-                      lng: selectedCluster.geometry.coordinates[0],
-                      surface: selectedCluster.properties.surface || 'Unknown',
-                      is_public: selectedCluster.properties.is_public ?? null, // Preserve null for unknown access
-                      has_lights: selectedCluster.properties.has_lights ?? null, // Preserve null for unknown
-                      school: selectedCluster.properties.school || false,
-                      cluster_group_name: selectedCluster.properties.cluster_group_name || 'Unknown Group',
-                      created_at: new Date().toISOString(),
-                      updated_at: new Date().toISOString()
-                    };
-                    handleEditClick(courtDetail);
-                  }}
-                  className="flex items-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors max-w-[calc(100%-1.5rem)]"
-                >
-                  {!user && <Lock className="h-3.5 w-3.5" />}
-                  Edit Court
-                </button>
-              </div>
+              {(() => {
+                const courtDetail: Court = {
+                  id: selectedCluster.properties.id || selectedCluster.id,
+                  name: selectedCluster.properties.name || 'Unknown Court',
+                  type: selectedCluster.properties.type || 'unknown',
+                  lat: selectedCluster.geometry.coordinates[1],
+                  lng: selectedCluster.geometry.coordinates[0],
+                  surface: selectedCluster.properties.surface || 'Unknown',
+                  is_public: selectedCluster.properties.is_public ?? null,
+                  has_lights: selectedCluster.properties.has_lights ?? null,
+                  school: selectedCluster.properties.school || false,
+                  cluster_group_name: selectedCluster.properties.cluster_group_name || 'Unknown Group',
+                  created_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString()
+                };
+                return (
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleEditClick(courtDetail)}
+                      className="flex-1 flex items-center justify-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+                    >
+                      {!user && <Lock className="h-3.5 w-3.5" />}
+                      Edit Court
+                    </button>
+                    {user && user.role === 'admin' && (
+                      <button
+                        onClick={() => handleDeleteCourt(courtDetail)}
+                        className="px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
+                        title="Delete court"
+                      >
+                        Delete
+                      </button>
+                    )}
+                    {user && user.role !== 'admin' && (
+                      <button
+                        onClick={() => handleRequestDeletion(courtDetail)}
+                        className="px-3 py-2 border border-red-300 hover:bg-red-50 text-red-600 text-sm font-medium rounded-lg transition-colors"
+                        title="Request deletion"
+                      >
+                        Request Delete
+                      </button>
+                    )}
+                  </div>
+                );
+              })()}
             </div>
           </Popup>
         )}
@@ -1185,6 +1386,20 @@ export default function CourtsMap({
         }}
         court={editingCourt}
         onSave={handleSaveCourt}
+        availableSports={availableSports}
+        availableSurfaces={availableSurfaces}
+      />
+
+      {/* Create Court Modal */}
+      <CreateCourtModal
+        isOpen={isCreateModalOpen}
+        onClose={() => {
+          setIsCreateModalOpen(false);
+          setPendingCourtLocation(null);
+        }}
+        lat={pendingCourtLocation?.lat ?? null}
+        lng={pendingCourtLocation?.lng ?? null}
+        onCreated={handleCreateCourt}
         availableSports={availableSports}
         availableSurfaces={availableSurfaces}
       />

--- a/frontend/components/CourtsMap.tsx
+++ b/frontend/components/CourtsMap.tsx
@@ -929,6 +929,10 @@ export default function CourtsMap({
       } else {
         toast.error('Failed to add court', { description: 'Please try again.' });
       }
+
+      // Re-throw so the modal's submit handler doesn't clear the form on failure.
+      // The user-facing error has already been toasted above.
+      throw err;
     }
   };
 

--- a/frontend/components/CourtsMap.tsx
+++ b/frontend/components/CourtsMap.tsx
@@ -1253,7 +1253,14 @@ export default function CourtsMap({
               key={uniqueKey}
               longitude={cluster.geometry.coordinates[0]}
               latitude={cluster.geometry.coordinates[1]}
-              onClick={() => handleClusterClick(cluster)}
+              onClick={(e) => {
+                // Stop the click from bubbling to the map's onClick. Otherwise in
+                // placement mode, clicking an existing marker would also drop a new
+                // court at that location (maplibre attaches map click to the canvas
+                // container, which contains marker DOM elements).
+                e.originalEvent.stopPropagation();
+                handleClusterClick(cluster);
+              }}
             >
               <div
                 className="cursor-pointer transform hover:scale-110 transition-transform"

--- a/frontend/components/CourtsMap.tsx
+++ b/frontend/components/CourtsMap.tsx
@@ -879,9 +879,10 @@ export default function CourtsMap({
         surface: data.surface,
         is_public: data.is_public,
         has_lights: data.has_lights,
+        court_name: data.name,
       });
 
-      setCourts(prev => [...prev, { ...created, cluster_group_name: data.cluster_group_name, name: data.name }]);
+      setCourts(prev => [...prev, { ...created, cluster_group_name: data.cluster_group_name, name: data.name ?? created.name }]);
       toast.success('Court added', { description: data.cluster_group_name });
       setIsCreateModalOpen(false);
       setPendingCourtLocation(null);

--- a/frontend/components/CreateCourtModal.tsx
+++ b/frontend/components/CreateCourtModal.tsx
@@ -79,7 +79,12 @@ export default function CreateCourtModal({
         is_public: formData.is_public === 'true',
         has_lights: formData.has_lights === 'true' ? true : formData.has_lights === 'false' ? false : null,
       });
+      // Only reset the form on success. On failure the parent re-throws after
+      // showing an error toast, so the user can fix and retry without re-typing.
       setFormData({ cluster_group_name: '', name: '', type: '', surface: '', is_public: 'true', has_lights: '' });
+    } catch {
+      // User-facing error already toasted by the parent; swallow here so React
+      // doesn't log an unhandled rejection.
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/components/CreateCourtModal.tsx
+++ b/frontend/components/CreateCourtModal.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState } from 'react';
+import { X, MapPin } from 'lucide-react';
+
+interface CreateCourtModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  lat: number | null;
+  lng: number | null;
+  onCreated: (data: {
+    cluster_group_name: string;
+    name: string | null;
+    type: string;
+    lat: number;
+    lng: number;
+    surface: string;
+    is_public: boolean;
+    has_lights: boolean | null;
+  }) => Promise<void>;
+  availableSports: string[];
+  availableSurfaces: string[];
+}
+
+export default function CreateCourtModal({
+  isOpen,
+  onClose,
+  lat,
+  lng,
+  onCreated,
+  availableSports,
+  availableSurfaces,
+}: CreateCourtModalProps) {
+  const [formData, setFormData] = useState({
+    cluster_group_name: '',
+    name: '',
+    type: '',
+    surface: '',
+    is_public: 'true',
+    has_lights: '',
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  if (!isOpen || lat === null || lng === null) return null;
+
+  const validate = (): string[] => {
+    const errs: string[] = [];
+    if (!formData.cluster_group_name.trim()) {
+      errs.push('Facility name is required');
+    } else if (formData.cluster_group_name.trim().length < 2) {
+      errs.push('Facility name must be at least 2 characters');
+    } else if (formData.cluster_group_name.trim().length > 100) {
+      errs.push('Facility name must be less than 100 characters');
+    }
+    if (!formData.type) errs.push('Sport type is required');
+    if (!formData.surface) errs.push('Surface type is required');
+    if (formData.name.trim().length > 100) errs.push('Court name must be less than 100 characters');
+    return errs;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs = validate();
+    if (errs.length > 0) {
+      setErrors(errs);
+      return;
+    }
+    setErrors([]);
+    setIsSubmitting(true);
+    try {
+      await onCreated({
+        cluster_group_name: formData.cluster_group_name.trim(),
+        name: formData.name.trim() || null,
+        type: formData.type,
+        lat,
+        lng,
+        surface: formData.surface,
+        is_public: formData.is_public === 'true',
+        has_lights: formData.has_lights === 'true' ? true : formData.has_lights === 'false' ? false : null,
+      });
+      setFormData({ cluster_group_name: '', name: '', type: '', surface: '', is_public: 'true', has_lights: '' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Add Court</h2>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+            <X className="h-5 w-5 text-gray-600" />
+          </button>
+        </div>
+
+        <div className="px-6 pt-4 flex items-center gap-2 text-sm text-gray-500">
+          <MapPin className="h-4 w-4 text-blue-500 shrink-0" />
+          <span>{lat.toFixed(5)}, {lng.toFixed(5)}</span>
+        </div>
+
+        {errors.length > 0 && (
+          <div className="mx-6 mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            <ul className="text-sm text-red-700 space-y-1">
+              {errors.map((err, i) => <li key={i}>{err}</li>)}
+            </ul>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Facility Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={formData.cluster_group_name}
+              onChange={(e) => setFormData({ ...formData, cluster_group_name: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="e.g., Rolph Playground"
+              autoFocus
+            />
+            <p className="text-xs text-gray-500 mt-1">The main name shown on the map</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Court Name</label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="e.g., basketball court (2 hoops)"
+            />
+            <p className="text-xs text-gray-500 mt-1">Optional: specific court identifier</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Sport Type <span className="text-red-500">*</span>
+            </label>
+            <select
+              value={formData.type}
+              onChange={(e) => setFormData({ ...formData, type: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Select sport...</option>
+              {availableSports.map((sport) => (
+                <option key={sport} value={sport}>{sport.charAt(0).toUpperCase() + sport.slice(1)}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Surface <span className="text-red-500">*</span>
+            </label>
+            <select
+              value={formData.surface}
+              onChange={(e) => setFormData({ ...formData, surface: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Select surface...</option>
+              {availableSurfaces.filter(s => s.toLowerCase() !== 'unknown').map((surface) => (
+                <option key={surface} value={surface}>{surface.charAt(0).toUpperCase() + surface.slice(1)}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Public Access</label>
+            <select
+              value={formData.is_public}
+              onChange={(e) => setFormData({ ...formData, is_public: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="true">Public</option>
+              <option value="false">Private</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Has Lights</label>
+            <select
+              value={formData.has_lights}
+              onChange={(e) => setFormData({ ...formData, has_lights: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Unknown</option>
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+          </div>
+
+          <div className="flex gap-3 pt-4 border-t border-gray-200">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 font-medium transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Adding...' : 'Add Court'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api/courtsApi.ts
+++ b/frontend/lib/api/courtsApi.ts
@@ -270,6 +270,7 @@ export async function createCourt(data: {
   surface?: string;
   is_public?: boolean;
   has_lights?: boolean | null;
+  court_name?: string | null;
 }): Promise<Court> {
   try {
     const token = getStoredToken();

--- a/frontend/lib/api/courtsApi.ts
+++ b/frontend/lib/api/courtsApi.ts
@@ -206,6 +206,105 @@ export async function updateCourt(
 }
 
 /**
+ * Delete a court (admin only)
+ */
+export async function deleteCourt(id: number): Promise<void> {
+  try {
+    const token = getStoredToken();
+    const response = await fetch(`${API_URL}/api/courts/${id}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw parseAPIError(response.status, errorData);
+    }
+  } catch (error) {
+    if (error instanceof APIError) throw error;
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError('Unable to connect to server.');
+    }
+    throw new NetworkError('An unexpected error occurred while deleting the court');
+  }
+}
+
+/**
+ * Request deletion of a court (contributor flow — emails admin)
+ */
+export async function requestCourtDeletion(id: number, reason?: string): Promise<void> {
+  try {
+    const token = getStoredToken();
+    const response = await fetch(`${API_URL}/api/courts/${id}/deletion-request`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ reason: reason || null }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw parseAPIError(response.status, errorData);
+    }
+  } catch (error) {
+    if (error instanceof APIError) throw error;
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError('Unable to connect to server.');
+    }
+    throw new NetworkError('An unexpected error occurred while submitting the deletion request');
+  }
+}
+
+/**
+ * Create a new court (requires auth token)
+ */
+export async function createCourt(data: {
+  name: string;
+  type: string;
+  location: { lat: number; lng: number };
+  surface?: string;
+  is_public?: boolean;
+  has_lights?: boolean | null;
+}): Promise<Court> {
+  try {
+    const token = getStoredToken();
+    const response = await fetch(`${API_URL}/api/courts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw parseAPIError(response.status, errorData);
+    }
+
+    const result = await response.json();
+
+    if (!result.success || !result.data) {
+      throw new APIError(result.error || 'Invalid response format', result.code || 'INVALID_RESPONSE', 500);
+    }
+
+    return result.data as Court;
+
+  } catch (error) {
+    if (error instanceof APIError) throw error;
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError('Unable to connect to server. Please check your internet connection.');
+    }
+    throw new NetworkError('An unexpected error occurred while creating the court');
+  }
+}
+
+/**
  * Get courts metadata (available sports and surface types)
  */
 export async function getMetadata(): Promise<CourtsMetadata> {


### PR DESCRIPTION
- Authenticated users can drop a pin on the map and create a court via a new CreateCourtModal; map flies to the new location and cache is invalidated so the court persists after refetch.
- Admins can hard-delete a court from the popup; contributors get a Request Delete button that emails the admin via Resend.
- Default surface_type on create changed from 'Unknown' to 'other' since 'Unknown' isn't in the Postgres enum.
- Magic-link rate limit bumped from 1/min to 3/min per email to tolerate retries.
- Dev: log magic-link URL on every request so corporate filters that drop localhost links don't block local testing.